### PR TITLE
Add `backup.Executor` for PostgreSQL backup

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/isutare412/web-memo/api
 
-go 1.22
+go 1.23.1
 
 require (
 	entgo.io/ent v0.12.5

--- a/backup/go.mod
+++ b/backup/go.mod
@@ -1,0 +1,3 @@
+module github.com/isutare412/web-memo/backup
+
+go 1.23.0

--- a/backup/internal/core/model/backup.go
+++ b/backup/internal/core/model/backup.go
@@ -1,0 +1,8 @@
+package model
+
+type DatabaseBackupRequest struct {
+	DatabaseName   string
+	User           string
+	Password       string
+	BackupFilePath string
+}


### PR DESCRIPTION
# Changes

- Add `backup.Executor`
  - Build and exec command for `pg_dump` usage.